### PR TITLE
Oldperl compatibility

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -20,10 +20,10 @@ repository.type = git
 [PodSyntaxTests]
 
 [Prereqs]
-perl = 5.016000
 DBIx::Class = 0.08196
 DBIx::Class::Helpers = 2.007004
 Class::C3::Componentised = 1.001000
 Test::More = 0.98
 Test::Deep = 0.110
 SQL::Translator = 0.11011
+Sub::Current = 0.02

--- a/lib/DBIx/Class/MaterializedPath.pm
+++ b/lib/DBIx/Class/MaterializedPath.pm
@@ -2,10 +2,12 @@ package DBIx::Class::MaterializedPath;
 
 # ABSTRACT: efficiently retrieve and search trees with DBIx::Class
 
-use 5.16.0;
 use warnings;
 
 use base 'DBIx::Class::Helper::Row::OnColumnChange';
+
+use Sub::Current;
+use English;
 
 use Class::C3::Componentised::ApplyHooks
    -before_apply => sub {
@@ -73,12 +75,22 @@ sub _install_after_column_change {
 
             my $rel = $path_info->{children_relationship};
             $self->_set_materialized_path($path_info);
-            __SUB__->($_) for $self->$rel->search({
-               # to avoid recursion
-               map +(
-                  "me.$_" => { '!=' => $self->get_column($_) },
-               ), $self->result_source->primary_columns
-            })->all
+            if ( $PERL_VERSION < 5.016 ) {
+                ROUTINE->($_) for $self->$rel->search({
+                   # to avoid recursion
+                   map +(
+                    "me.$_" => { '!=' => $self->get_column($_) },
+                 ), $self->result_source->primary_columns
+              })->all
+            }
+            else {
+                __SUB__->($_) for $self->$rel->search({
+                   # to avoid recursion
+                   map +(
+                      "me.$_" => { '!=' => $self->get_column($_) },
+                   ), $self->result_source->primary_columns
+                })->all
+            }
          },
       });
    }

--- a/lib/DBIx/Class/MaterializedPath/NativeRecursion.pm
+++ b/lib/DBIx/Class/MaterializedPath/NativeRecursion.pm
@@ -1,0 +1,24 @@
+package DBIx::Class::MaterializedPath;
+
+use 5.016;
+
+use warnings;
+use strict;
+
+sub _get_column_change_method {
+    my ( $self, $path_info ) = @_;
+
+    return sub {
+        my $self = shift;
+        my $rel = $path_info->{children_relationship};
+        $self->_set_materialized_path($path_info);
+        __SUB__->($_) for $self->$rel->search({
+            # to avoid recursion
+            map +(
+                "me.$_" => { '!=' => $self->get_column($_) },
+            ), $self->result_source->primary_columns
+        })->all
+    };
+}
+
+1;

--- a/lib/DBIx/Class/MaterializedPath/SubCurrentRecursion.pm
+++ b/lib/DBIx/Class/MaterializedPath/SubCurrentRecursion.pm
@@ -1,0 +1,24 @@
+package DBIx::Class::MaterializedPath;
+
+use warnings;
+use strict;
+
+use Sub::Current;
+
+sub _get_column_change_method {
+    my ( $self, $path_info ) = @_;
+
+    return sub {
+        my $self = shift;
+        my $rel = $path_info->{children_relationship};
+        $self->_set_materialized_path($path_info);
+        ROUTINE->($_) for $self->$rel->search({
+            # to avoid recursion
+            map +(
+                "me.$_" => { '!=' => $self->get_column($_) },
+            ), $self->result_source->primary_columns
+        })->all
+    };
+}
+
+1;


### PR DESCRIPTION
Adding a workaround for pre-5.16 versions of Perl. 

This involves adding Sub::Current to the module's listed prereqs in dist.ini, though its use pragma isn't actually encountered unless the current Perl interpreter is < 5.16.

Per fREW's request on his blog (http://blog.afoolishmanifesto.com/archives/1758), if the current interpreter is >= 5.16, we'll continue to use the **SUB** builtin instead.
